### PR TITLE
Update link to Clutter Project documentation

### DIFF
--- a/animation.py
+++ b/animation.py
@@ -1,4 +1,4 @@
-from math import sqrt, cos, sin, pi
+﻿from math import sqrt, cos, sin, pi
 import pygame
 import sys
 
@@ -297,6 +297,9 @@ class Animation(pygame.sprite.Sprite):
 class AnimationTransition(object):
     """Collection of animation functions to be used with the Animation object.
     Easing Functions ported to Kivy from the Clutter Project
+    https://developer.gnome.org/clutter/1.24/ClutterAlpha.html
+
+    Original link, now dead:
     http://www.clutter-project.org/docs/clutter/stable/ClutterAlpha.html
 
     The `progress` parameter in each animation function is in the range 0-1.


### PR DESCRIPTION
I noticed that the [link to the documentation for the Clutter Project](http://www.clutter-project.org/docs/clutter/stable/ClutterAlpha.html) in animation.py was now a dead link, so I did some hunting around and found what I _think_ is the [correct current link](https://developer.gnome.org/clutter/1.24/ClutterAlpha.html).

I'm mainly submitting this pull request to learn about how the process works, and will not be offended if you deny the request!
